### PR TITLE
fix style sheet import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
-import type { Metadata } from "next";
+import "./globals.css";
+
 import { Inter } from "next/font/google";
+
+import type { Metadata } from "next";
 
 const inter = Inter({ subsets: ["latin"] });
 


### PR DESCRIPTION
This pull request includes a minor change in the `app/layout.tsx` file to adjust the import order and include a global stylesheet.

* Adjusted import order: Moved the `Metadata` type import below the import for `globals.css` to ensure the global styles are loaded first.